### PR TITLE
Add backend walking skeleton with health endpoint (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,57 @@
+###############################################
+# Global ignores
+###############################################
+*.DS_Store
+*.tmp
+*.log
+
+###############################################
+# .NET / C# Backend
+###############################################
+# Build output
+bin/
+obj/
+out/
+.vs/
+
+# User-specific files
+*.user
+*.userosscache
+*.suo
+*.sln.docstates
+
+# VS Code settings (optional ignore)
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
+
+# Rider / JetBrains IDE
+.idea/
+
+# NuGet packages
+*.nupkg
+# Optional: If you use a local packages folder
+packages/
+
+# Coverage reports
+coverage/
+*.lcov
+
+###############################################
+# Frontend (React / Vite)
+###############################################
+# Node modules
+**/node_modules/
+
+# Build output (Vite or CRA)
+dist/
+build/
+
+# Environment files
+*.env
+*.env.local
+*.env.*.local
+
+# Mac, Windows junk
+Thumbs.db
+ehthumbs.db

--- a/README.md
+++ b/README.md
@@ -95,15 +95,44 @@ cd todo-mvp
 ```
 
 
-### 5.3 Run the Backend (API)
+### 5.3 Run the Backend (TodoMvp.Api)
 
-From the project root:
-```bash
-cd src/backend
-# TODO: add actual commands once the .NET project is created, e.g.:
-# dotnet restore
-# dotnet run
-```
+The backend is a .NET 10 Web API project located under `src/backend/TodoMvp.Api`.
+
+#### Prerequisites
+
+- .NET SDK 10 installed
+
+You can verify your installation with:
+
+    dotnet --version
+
+#### How to run the backend
+
+From the repository root:
+
+    cd src/backend/TodoMvp.Api
+    dotnet run
+
+You should see console output indicating that the application is listening on HTTP/HTTPS ports, for example:
+
+    Now listening on: https://localhost:7157
+    Now listening on: http://localhost:5157
+
+#### Health Check Endpoint
+
+To verify the backend is running, call the health endpoint in a browser or with a tool like curl/Postman:
+
+    GET https://localhost:<port>/api/health
+
+Expected JSON response shape:
+
+    {
+      "status": "ok",
+      "timestampUtc": "2025-01-01T12:00:00Z"
+    }
+
+(The exact `timestampUtc` value will vary.)
 
 The API will listen on a local port (e.g., ```http://localhost:5000```) depending on configuration.
 

--- a/src/backend/TodoMvp/TodoMvp.Api/Controllers/HealthController.cs
+++ b/src/backend/TodoMvp/TodoMvp.Api/Controllers/HealthController.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace TodoMvp.Api.Controllers
+{
+    [Route("api/health")]
+    [ApiController]
+    public class HealthController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult Get()
+        {
+            var response = new
+            {
+                status = "ok",
+                timestampUtc = DateTime.UtcNow
+            };
+
+            return Ok(response);
+        }
+    }
+}

--- a/src/backend/TodoMvp/TodoMvp.Api/Program.cs
+++ b/src/backend/TodoMvp/TodoMvp.Api/Program.cs
@@ -1,0 +1,23 @@
+var builder = WebApplication.CreateBuilder(args);
+
+// Add services to the container.
+
+builder.Services.AddControllers();
+// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
+builder.Services.AddOpenApi();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/src/backend/TodoMvp/TodoMvp.Api/Properties/launchSettings.json
+++ b/src/backend/TodoMvp/TodoMvp.Api/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5025",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7157;http://localhost:5025",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/backend/TodoMvp/TodoMvp.Api/TodoMvp.Api.csproj
+++ b/src/backend/TodoMvp/TodoMvp.Api/TodoMvp.Api.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/backend/TodoMvp/TodoMvp.Api/TodoMvp.Api.http
+++ b/src/backend/TodoMvp/TodoMvp.Api/TodoMvp.Api.http
@@ -1,0 +1,6 @@
+@TodoMvp.Api_HostAddress = http://localhost:5025
+
+GET {{TodoMvp.Api_HostAddress}}/api/health
+Accept: application/json
+
+###

--- a/src/backend/TodoMvp/TodoMvp.Api/appsettings.Development.json
+++ b/src/backend/TodoMvp/TodoMvp.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/backend/TodoMvp/TodoMvp.Api/appsettings.json
+++ b/src/backend/TodoMvp/TodoMvp.Api/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/backend/TodoMvp/TodoMvp.slnx
+++ b/src/backend/TodoMvp/TodoMvp.slnx
@@ -1,0 +1,3 @@
+<Solution>
+  <Project Path="TodoMvp.Api/TodoMvp.Api.csproj" />
+</Solution>


### PR DESCRIPTION
### Summary
Implements the backend portion of the Walking Skeleton.  
Adds a minimal .NET 10 Web API with a Health endpoint and removes the template WeatherForecast files.

### Changes
- Removed WeatherForecast controller and model
- Added HealthController exposing GET /api/health
- Cleaned Program.cs to remove template mappings
- Updated README with backend run instructions and health check documentation

### How to Test
1. Navigate to the backend project folder:  
   cd src/backend/TodoMvp.Api

2. Run the API:  
   dotnet run

3. In a browser or tool like curl/Postman, call:  
   https://localhost:<port>/api/health

4. Expected response contains:  
   - status = "ok"  
   - timestampUtc (current UTC timestamp)

### Linked Issue
Closes #1
